### PR TITLE
consider special cases while parsing ingredients

### DIFF
--- a/lib/allrecipes/ingredients_parser.rb
+++ b/lib/allrecipes/ingredients_parser.rb
@@ -23,7 +23,9 @@ class IngredientsParser
 
   def add_ingredient_to_list(amount, ingredient_name)
     if amount && ingredient_name #some recipes have empty ingredients
-      quantity,unit = amount.text.split(" ")
+      _details = amount.text.split(" ")
+      quantity = eval "#{_details[0]}.0"
+      unit = _details.last
       @ingredients << { quantity: quantity.to_f, unit: unit, name: ingredient_name.text }
     end
   end

--- a/spec/ingredient_parser_spec.rb
+++ b/spec/ingredient_parser_spec.rb
@@ -16,8 +16,16 @@ describe IngredientsParser do
     expect(@ing_parser.ingredients.first[:quantity]).to eq 1
   end
 
+  it "should have the correct quantity even if there is additional info" do
+    expect(@ing_parser.ingredients[5][:quantity]).to eq 2
+  end
+
   it "should have the correct unit" do
     expect(@ing_parser.ingredients.first[:unit]).to eq "pound"
+  end
+
+  it "should have the correct unit even if there is additional info" do
+    expect(@ing_parser.ingredients[5][:unit]).to eq "cans"
   end
 
   it "should have the correct ingredient name" do


### PR DESCRIPTION
consider special cases  such as '1 (28 ounce) can crushed tomatoes' when parsing ingredients
